### PR TITLE
Use device test to check if tempdir can be used

### DIFF
--- a/getdev_nonposix.go
+++ b/getdev_nonposix.go
@@ -1,0 +1,21 @@
+// +build !darwin,!dragonfly,!freebsd,!linux,!netbsd,!openbsd,!solaris
+
+// Copyright 2019 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package renameio
+
+func getDev(path string) (int, bool) {
+	return 0, false
+}

--- a/getdev_posix.go
+++ b/getdev_posix.go
@@ -1,0 +1,35 @@
+// +build darwin dragonfly freebsd linux netbsd openbsd solaris
+
+// Copyright 2019 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package renameio
+
+import (
+	"os"
+	"syscall"
+)
+
+// getDev returns the ID of the device containing path and whether the
+// operation was successful.
+func getDev(path string) (int, bool) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return 0, false
+	}
+	if stat, ok := info.Sys().(*syscall.Stat_t); ok {
+		return int(stat.Dev), true
+	}
+	return 0, false
+}


### PR DESCRIPTION
I'm not sure if this is correct, but if it is then it's a simplification and speed improvement.

Basically, instead of creating a test temporary file and trying to rename it to determine if the return value of `os.TempDir()` can be used, we directly compare the device numbers and use the returned value if the device numbers are the same.

The original code has some behaviors that are not reflected in this approach. For example, the original code would fallback to `filepath.Dir(dest)` if it encountered any errors. Errors that might be encountered include not having permission to write to either directory (`os.TempDir()` or `filepath.Dir(dest)`) or disk full situations. Whether it is correct to fallback to `filepath.Dir(dest)` in these situations is debatable.