### PR TITLE
Add TempDirCache to cache TempDir results, fixes #13

### DIFF
--- a/getdev_nonposix.go
+++ b/getdev_nonposix.go
@@ -1,0 +1,21 @@
+// +build !darwin,!dragonfly,!freebsd,!linux,!netbsd,!openbsd,!solaris
+
+// Copyright 2019 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package renameio
+
+func getDev(path string) (int, bool) {
+	return 0, false
+}

--- a/getdev_posix.go
+++ b/getdev_posix.go
@@ -1,0 +1,35 @@
+// +build darwin dragonfly freebsd linux netbsd openbsd solaris
+
+// Copyright 2019 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package renameio
+
+import (
+	"os"
+	"syscall"
+)
+
+// getDev returns the ID of the device containing path and whether the
+// operation was successful.
+func getDev(path string) (int, bool) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return 0, false
+	}
+	if stat, ok := info.Sys().(*syscall.Stat_t); ok {
+		return int(stat.Dev), true
+	}
+	return 0, false
+}

--- a/internal/tempdircache_test/main.go
+++ b/internal/tempdircache_test/main.go
@@ -1,0 +1,43 @@
+// Copyright 2019 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Command tempdircache_test tests TempDirCache.
+//
+// For each dest (passed as command line arguments), it prints the dest, the
+// result of renameio.TempDir(dest), and the result of TempDirCache.Get(dest).
+// When given multiple dests are on the same filesystem but on a different
+// filesystem to the result of os.TempDir(), TempDirCache.Get(dest) should
+// repeatedly return the first result of renameio.TempDir(dest), whereas
+// renameio.TempDir(dest) should return different values.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/google/renameio"
+)
+
+func main() {
+	flag.Parse()
+	tempDirCache := renameio.NewTempDirCache()
+	tw := tabwriter.NewWriter(os.Stdout, 0, 8, 0, '\t', 0)
+	fmt.Fprintf(tw, "dest\trenameio.TempDir(dest)\tTempDirCache.Get(dest)\n")
+	for _, dest := range flag.Args() {
+		fmt.Fprintf(tw, "%s\t%s\t%s\n", dest, renameio.TempDir(dest), tempDirCache.Get(dest))
+	}
+	tw.Flush()
+}

--- a/tempdircache.go
+++ b/tempdircache.go
@@ -1,0 +1,44 @@
+// Copyright 2019 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package renameio
+
+// A TempDirCache caches calls to TempDir. Destinations on the same device
+// share the same temporary directory.
+type TempDirCache struct {
+	cache map[int]string
+}
+
+// NewTempDirCache returns a new TempDirCache.
+func NewTempDirCache() *TempDirCache {
+	return &TempDirCache{
+		cache: make(map[int]string),
+	}
+}
+
+// Get is the equivalent of TempDir, except using c is a cache.
+func (c *TempDirCache) Get(dest string) string {
+	dev, devOK := getDev(dest)
+	if devOK {
+		tempDir, ok := c.cache[dev]
+		if ok {
+			return tempDir
+		}
+	}
+	tempDir := TempDir(dest)
+	if devOK {
+		c.cache[dev] = tempDir
+	}
+	return tempDir
+}


### PR DESCRIPTION
This is an alternative solution to #13. Note that it shares some code (`getDev`) with #14 but addresses separate functionality.

This PR adds `TempDirCache`, which is an intelligent cache for `TempDir`. Temporary directories can be re-used for all destination directories on the same device.

It's not clear how to write an automated test for this, as you'd need either to mount a different filesystem (which the user running the test might not have privileges to do) or mock out `os.Stat` (hooks to do this aren't in place).

Instead, I've included `internal/tempdircache_test` which exercises the code. See the comment in `internal/tempdircache_test/main.go` for details, but you can see the cache in action on modern Linux systems with:

    $ go run ./internal/tempdircache_test $XDG_RUNTIME_DIR $XDG_RUNTIME_DIR/systemd
