### PR TITLE
Remove Windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,16 @@ correct sequence of operations hard to identify:
 This package attempts to get all of these details right, provides an intuitive,
 yet flexible API and caters to use-cases where high performance is required.
 
+## Windows support
+
+It is [not possible to reliably write files atomically on
+Windows](https://github.com/golang/go/issues/22397#issuecomment-498856679), and
+[`chmod` is not reliably supported by the Go standard library on
+Windows](https://github.com/google/renameio/issues/17).
+
+As it is not possible to provide a correct implementation, this package does not
+export any functions on Windows.
+
 ## Disclaimer
 
 This is not an official Google product (experimental or otherwise), it

--- a/example_test.go
+++ b/example_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build !windows
+
 package renameio_test
 
 import (

--- a/symlink_test.go
+++ b/symlink_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build darwin dragonfly freebsd linux nacl netbsd openbsd solaris windows
+// +build !windows
 
 package renameio
 

--- a/tempfile.go
+++ b/tempfile.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build !windows
+
 package renameio
 
 import (

--- a/tempfile_linux_test.go
+++ b/tempfile_linux_test.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build linux
-
 package renameio
 
 import (

--- a/writefile.go
+++ b/writefile.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build !windows
+
 package renameio
 
 import "os"

--- a/writefile_test.go
+++ b/writefile_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build darwin dragonfly freebsd linux nacl netbsd openbsd solaris windows
+// +build !windows
 
 package renameio
 


### PR DESCRIPTION
This is an alternative "fix" to #1 and #17. It drops any pretense of Windows support by not providing any functionality on Windows, i.e. when compiled on Windows, the package is empty.

The reasons for this are:
* On Windows, it is not possible to atomically replace a file, so this library cannot serve its intended purpose.
* Windows does not support UNIX-like file permissions, and pretending to support them (as the Go standard library does) only causes surprises and unexpected behavior (as @andhe [describes](https://github.com/google/renameio/issues/17#issuecomment-687898524)).

By providing an empty package on Windows, users will have to work around these limitations in their application code when building on Windows.