### PR TITLE
add GitHub Action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,38 @@
+name: Test
+on:
+  pull_request:
+  push:
+    branches:
+    - master
+    tags:
+    - v*
+jobs:
+  test:
+    strategy:
+      matrix:
+        go-version:
+        - 1.14.x
+        - 1.15.x
+        os:
+        - macos-latest
+        - ubuntu-latest
+        - windows-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Set up Go
+      uses: actions/setup-go@v1
+      with:
+        go-version: ${{ matrix.go-version }}
+    - name: Cache Go modules
+      uses: actions/cache@v1
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Build
+      run: go build ./...
+    - name: Test
+      run: go test ./...


### PR DESCRIPTION
This PR adds a GitHub Action CI to build and test the package on Linux, macOS, and Windows. The main advantage over the existing Travis CI is the extra operating system support. If this is merged, I'll create a follow-up PR to remove Travis CI support.

Note that AFAIK it is not possible to test this Action without this being merged into `master`, but it *should* work.