### PR TITLE
Respect umask in WriteFile

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,19 @@ correct sequence of operations hard to identify:
 This package attempts to get all of these details right, provides an intuitive,
 yet flexible API and caters to use-cases where high performance is required.
 
+## Major changes in v2
+
+With major version renameio/v2, `renameio.WriteFile` changes the way that
+permissions are handled. Before version 2, files were created with the
+permissions passed to the function, ignoring the
+[umask](https://en.wikipedia.org/wiki/Umask). From version 2 onwards, these
+permissions are further modified by process' umask (usually the user's
+preferred umask).
+
+If you were relying on the umask being ignored, add the
+`renameio.IgnoreUmask()` option to your `renameio.WriteFile` calls when
+upgrading to v2.
+
 ## Windows support
 
 It is [not possible to reliably write files atomically on

--- a/option.go
+++ b/option.go
@@ -40,7 +40,8 @@ func WithTempDir(dir string) Option {
 }
 
 // WithPermissions sets the permissions for the target file while respecting
-// the umask(2). Bits set in the umask are removed from the permissions given.
+// the umask(2). Bits set in the umask are removed from the permissions given
+// unless IgnoreUmask is used.
 func WithPermissions(perm os.FileMode) Option {
 	perm &= os.ModePerm
 	return optionFunc(func(cfg *config) {
@@ -48,8 +49,17 @@ func WithPermissions(perm os.FileMode) Option {
 	})
 }
 
+// IgnoreUmask causes the permissions configured using WithPermissions to be
+// applied directly without applying the umask.
+func IgnoreUmask() Option {
+	return optionFunc(func(cfg *config) {
+		cfg.ignoreUmask = true
+	})
+}
+
 // WithStaticPermissions sets the permissions for the target file ignoring the
-// umask(2). This is equivalent to calling Chmod().
+// umask(2). This is equivalent to calling Chmod() on the file handle or using
+// WithPermissions in combination with IgnoreUmask.
 func WithStaticPermissions(perm os.FileMode) Option {
 	perm &= os.ModePerm
 	return optionFunc(func(cfg *config) {

--- a/tempfile.go
+++ b/tempfile.go
@@ -186,6 +186,7 @@ type config struct {
 	dir, path       string
 	createPerm      os.FileMode
 	attemptPermCopy bool
+	ignoreUmask     bool
 	chmod           *os.FileMode
 }
 
@@ -197,7 +198,8 @@ type config struct {
 // result of TempDir(filepath.Base(path)) with the WithTempDir option.
 //
 // The file's permissions will be (0600 & ^umask). Use WithPermissions,
-// WithStaticPermissions and WithExistingPermissions to control them.
+// IgnoreUmask, WithStaticPermissions and WithExistingPermissions to control
+// them.
 func NewPendingFile(path string, opts ...Option) (*PendingFile, error) {
 	cfg := config{
 		path:       path,
@@ -206,6 +208,10 @@ func NewPendingFile(path string, opts ...Option) (*PendingFile, error) {
 
 	for _, o := range opts {
 		o.apply(&cfg)
+	}
+
+	if cfg.ignoreUmask && cfg.chmod == nil {
+		cfg.chmod = &cfg.createPerm
 	}
 
 	if cfg.attemptPermCopy {

--- a/tempfile.go
+++ b/tempfile.go
@@ -213,6 +213,10 @@ func NewPendingFile(path string, opts ...Option) (*PendingFile, error) {
 		if existing, err := os.Lstat(cfg.path); err == nil && existing.Mode().IsRegular() {
 			perm := existing.Mode() & os.ModePerm
 			cfg.chmod = &perm
+
+			// Try to already create file with desired permissions; at worst
+			// a chmod will be needed afterwards.
+			cfg.createPerm = perm
 		} else if err != nil && !os.IsNotExist(err) {
 			return nil, err
 		}

--- a/tempfile_test.go
+++ b/tempfile_test.go
@@ -228,6 +228,20 @@ func TestPendingFileCreation(t *testing.T) {
 			want:     "replaced:custom tempdir",
 			wantPerm: 0o612,
 		},
+		{
+			name:     "ignore umask",
+			path:     filepath.Join(t.TempDir(), "ignore umask"),
+			options:  []Option{IgnoreUmask(), WithPermissions(0o644)},
+			want:     "replaced:ignore umask",
+			wantPerm: 0o644,
+		},
+		{
+			name:     "ignore umask with static permissions",
+			path:     filepath.Join(t.TempDir(), "ignore umask"),
+			options:  []Option{IgnoreUmask(), WithStaticPermissions(0o632), WithPermissions(0o765)},
+			want:     "replaced:ignore umask with static permissions",
+			wantPerm: 0o632,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			if tc.umask != 0 {

--- a/writefile.go
+++ b/writefile.go
@@ -20,17 +20,17 @@ import "os"
 
 // WriteFile mirrors ioutil.WriteFile, replacing an existing file with the same
 // name atomically.
-func WriteFile(filename string, data []byte, perm os.FileMode) error {
-	t, err := TempFile("", filename)
+func WriteFile(filename string, data []byte, perm os.FileMode, opts ...Option) error {
+	opts = append([]Option{
+		WithPermissions(perm),
+		WithExistingPermissions(),
+	}, opts...)
+
+	t, err := NewPendingFile(filename, opts...)
 	if err != nil {
 		return err
 	}
 	defer t.Cleanup()
-
-	// Set permissions before writing data, in case the data is sensitive.
-	if err := t.Chmod(perm); err != nil {
-		return err
-	}
 
 	if _, err := t.Write(data); err != nil {
 		return err

--- a/writefile_test.go
+++ b/writefile_test.go
@@ -81,3 +81,101 @@ func TestWriteFileIgnoreUmask(t *testing.T) {
 		t.Errorf("got permissions %04o, want %04o", gotPerm, wantPerm)
 	}
 }
+
+func TestWriteFileEquivalence(t *testing.T) {
+	type writeFunc func(string, []byte, os.FileMode, ...Option) error
+	type test struct {
+		name   string
+		fn     writeFunc
+		perm   os.FileMode
+		umask  os.FileMode
+		exists bool
+	}
+
+	var tests []test
+
+	for _, wf := range []struct {
+		name string
+		fn   writeFunc
+	}{
+		{
+			name: "WriteFile",
+			fn:   WriteFile,
+		},
+		{
+			name: "ioutil",
+			fn: func(filename string, data []byte, perm os.FileMode, opts ...Option) error {
+				return ioutil.WriteFile(filename, data, perm)
+			},
+		},
+	} {
+		for _, perm := range []os.FileMode{0o755, 0o644, 0o400, 0o765} {
+			for _, umask := range []os.FileMode{0o000, 0o011, 0o007, 0o027, 0o077} {
+				for _, exists := range []bool{false, true} {
+					name := fmt.Sprintf("%s/perm%04o/umask%04o", wf.name, perm, umask)
+					if exists {
+						name += "/exists"
+					}
+
+					tests = append(tests, test{
+						name:   name,
+						fn:     wf.fn,
+						perm:   perm,
+						umask:  umask,
+						exists: exists,
+					})
+				}
+			}
+		}
+	}
+
+	const existingPerm os.FileMode = 0o654
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			withUmask(t, tc.umask)
+
+			maskedPerm := tc.perm & ^tc.umask
+
+			filename := filepath.Join(t.TempDir(), "test.txt")
+
+			if tc.exists {
+				// Create file in preparation for replacement
+				fh, err := os.Create(filename)
+				if err != nil {
+					t.Errorf("Create(%q) failed: %v", filename, err)
+				}
+
+				if err := fh.Chmod(existingPerm); err != nil {
+					t.Errorf("Chmod() failed: %v", err)
+				}
+
+				fh.Close()
+
+				maskedPerm = existingPerm
+			}
+
+			wantData := []byte("content\n")
+
+			if err := tc.fn(filename, wantData, tc.perm); err != nil {
+				t.Fatal(err)
+			}
+
+			gotData, err := ioutil.ReadFile(filename)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(gotData, wantData) {
+				t.Errorf("got data %v, want data %v", gotData, wantData)
+			}
+
+			fi, err := os.Stat(filename)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if gotPerm := fi.Mode() & os.ModePerm; gotPerm != maskedPerm {
+				t.Errorf("got permissions %04o, want %04o", gotPerm, maskedPerm)
+			}
+		})
+	}
+}

--- a/writefile_test.go
+++ b/writefile_test.go
@@ -25,13 +25,7 @@ import (
 )
 
 func TestWriteFile(t *testing.T) {
-	d, err := ioutil.TempDir("", "tempdirtest")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(d)
-
-	filename := filepath.Join(d, "hello.sh")
+	filename := filepath.Join(t.TempDir(), "hello.sh")
 
 	wantData := []byte("#!/bin/sh\necho \"Hello World\"\n")
 	wantPerm := os.FileMode(0755)


### PR DESCRIPTION
Fixes #33 by taking the umask into consideration in `renameio.WriteFile`.