### PR TITLE
proposal: add option to extend atomicity to io.Closer

### DIFF
--- a/option.go
+++ b/option.go
@@ -77,3 +77,12 @@ func WithExistingPermissions() Option {
 		c.attemptPermCopy = true
 	})
 }
+
+// WithReplaceOnClose causes Close() on the PendingFile to actually call
+// CloseAtomicallyReplace(). This means PendingFile implements io.Closer while
+// maintaining atomicity per default.
+func WithReplaceOnClose() Option {
+	return optionFunc(func(c *config) {
+		c.renameOnClose = true
+	})
+}

--- a/option.go
+++ b/option.go
@@ -78,7 +78,7 @@ func WithExistingPermissions() Option {
 	})
 }
 
-// WithReplaceOnClose causes Close() on the PendingFile to actually call
+// WithReplaceOnClose causes PendingFile.Close() to actually call
 // CloseAtomicallyReplace(). This means PendingFile implements io.Closer while
 // maintaining atomicity per default.
 func WithReplaceOnClose() Option {

--- a/tempfile.go
+++ b/tempfile.go
@@ -170,8 +170,8 @@ func (t *PendingFile) CloseAtomicallyReplace() error {
 	return nil
 }
 
-// Close wraps os.File.Close, optionally calling CloseAtomicallyReplace instead if WithReplaceOnClose is used when
-// creating the PendingFile.
+// Close closes the file. By default it just calls Close() on the underlying file. For PendingFiles created with
+// WithReplaceOnClose it calls CloseAtomicallyReplace() instead.
 func (t *PendingFile) Close() error {
 	if t.replaceOnClose {
 		return t.CloseAtomicallyReplace()

--- a/tempfile.go
+++ b/tempfile.go
@@ -114,9 +114,10 @@ func tempDir(dir, dest string) string {
 type PendingFile struct {
 	*os.File
 
-	path   string
-	done   bool
-	closed bool
+	path           string
+	done           bool
+	closed         bool
+	replaceOnClose bool
 }
 
 // Cleanup is a no-op if CloseAtomicallyReplace succeeded, and otherwise closes
@@ -131,7 +132,7 @@ func (t *PendingFile) Cleanup() error {
 	// reporting, there is nothing the caller can recover here.
 	var closeErr error
 	if !t.closed {
-		closeErr = t.Close()
+		closeErr = t.File.Close()
 	}
 	if err := os.Remove(t.Name()); err != nil {
 		return err
@@ -159,7 +160,7 @@ func (t *PendingFile) CloseAtomicallyReplace() error {
 		return err
 	}
 	t.closed = true
-	if err := t.Close(); err != nil {
+	if err := t.File.Close(); err != nil {
 		return err
 	}
 	if err := os.Rename(t.Name(), t.path); err != nil {
@@ -167,6 +168,15 @@ func (t *PendingFile) CloseAtomicallyReplace() error {
 	}
 	t.done = true
 	return nil
+}
+
+// Close wraps os.File.Close, optionally calling CloseAtomicallyReplace instead if WithReplaceOnClose is used when
+// creating the PendingFile.
+func (t *PendingFile) Close() error {
+	if t.replaceOnClose {
+		return t.CloseAtomicallyReplace()
+	}
+	return t.File.Close()
 }
 
 // TempFile creates a temporary file destined to atomically creating or
@@ -189,6 +199,7 @@ type config struct {
 	attemptPermCopy bool
 	ignoreUmask     bool
 	chmod           *os.FileMode
+	renameOnClose   bool
 }
 
 // NewPendingFile creates a temporary file destined to atomically creating or
@@ -244,7 +255,7 @@ func NewPendingFile(path string, opts ...Option) (*PendingFile, error) {
 		}
 	}
 
-	return &PendingFile{File: f, path: cfg.path}, nil
+	return &PendingFile{File: f, path: cfg.path, replaceOnClose: cfg.renameOnClose}, nil
 }
 
 // Symlink wraps os.Symlink, replacing an existing symlink with the same name


### PR DESCRIPTION
Currently the `PendingFile` implements `io.Closer` by simply embedding `*os.File`, so a "normal" `Close()` closes the underlying tempfile without renaming it. This means using the `PendingFile` as a `io.Closer` needs explicit action on both the happy and sad paths:
- in the happy path (no errors), `Close()` doesn't rename the file, so you need `CloseAtomicallyReplace()`
- in the sad path , `Close()` leaves the dangling tempfile, so you need `Cleanup()`

This PR is my proposal of adding an option where at least the happy path behaves more like a normal file: writing and closing leaves you with the intended file; sad path needs extra steps (usually removing the file; in our case `Cleanup()`).

WDYT?