### PR TITLE
Add chown step to NewPendingFile

### DIFF
--- a/option.go
+++ b/option.go
@@ -86,3 +86,19 @@ func WithReplaceOnClose() Option {
 		c.renameOnClose = true
 	})
 }
+
+// WithUserID configures the file creation to try to change ownership to the
+// specified user ID. This is equivalent to calling Chown() on the file handle.
+func WithUserID(uid int) Option {
+	return optionFunc(func(c *config) {
+		c.uid = uid
+	})
+}
+
+// WithGroupID configures the file creation to try to change ownership to the
+// specified group ID. This is equivalent to calling Chown() on the file handle.
+func WithGroupID(gid int) Option {
+	return optionFunc(func(c *config) {
+		c.gid = gid
+	})
+}

--- a/tempfile.go
+++ b/tempfile.go
@@ -200,6 +200,8 @@ type config struct {
 	ignoreUmask     bool
 	chmod           *os.FileMode
 	renameOnClose   bool
+	uid             int
+	gid             int
 }
 
 // NewPendingFile creates a temporary file destined to atomically creating or
@@ -216,6 +218,8 @@ func NewPendingFile(path string, opts ...Option) (*PendingFile, error) {
 	cfg := config{
 		path:       path,
 		createPerm: defaultPerm,
+		uid:        -1,
+		gid:        -1,
 	}
 
 	for _, o := range opts {
@@ -252,6 +256,12 @@ func NewPendingFile(path string, opts ...Option) (*PendingFile, error) {
 			if err := f.Chmod(*cfg.chmod); err != nil {
 				return nil, err
 			}
+		}
+	}
+
+	if cfg.uid != -1 || cfg.gid != -1 {
+		if err := f.Chown(cfg.uid, cfg.gid); err != nil {
+			return nil, err
 		}
 	}
 


### PR DESCRIPTION
Hello,

At the creation of a file, it could happen to need to apply a `chown` on top of a `chmod`.
As `NewPendingFile` provides a generic option interface, I figured it would be beneficial to integrate this behaviour as close to the creation as possible.

These proposed changes integrate two new options `WithUserId` and `WithGroupId`. Those options are by default to -1, the no-op value of `file.Chown`.

Of course, the compatibility of those changes is dependent on the Chown operation, which is currently not compatible with Windows systems.

Let me know what you think about it.